### PR TITLE
Add Scalekit

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ A community curated list of headless commerce related APIs, products, and servic
 - [Magic Link](https://magic.link) &mdash; One SDK for passwordless, WebAuthn, and social login - fully customizable.
 - [Clerk](https://clerk.dev/) &mdash; More than authentication. Complete User Management.
 - [WorkOS](https://workos.com) &mdash; Your app, Enterprise Ready.
+- [Scalekit](https://www.scalekit.com) &mdash; Add enterprise SSO (SAML, OIDC) and SCIM provisioning on top of existing auth systems like Auth0, Firebase, or Cognito without rewrites.
 
 ## Communication
 


### PR DESCRIPTION
Scalekit is a developer-first platform that helps B2B SaaS teams support enterprise authentication requirements including SAML/OIDC-based SSO, SCIM provisioning on top of their existing auth stack.

It’s designed for developers who want to keep their current setup (Firebase Auth, Auth0, Cognito, etc.) but need to support enterprise customers without rebuilding everything.

Docs: https://docs.scalekit.com  
Blog: https://scalekit.com/blog

Let me know if this fits the criteria or should be reworded. Thanks for maintaining this awesome list!