### PR TITLE
Add Spree Commerce to Headless Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A community curated list of headless commerce related APIs, products, and servic
 - [commercelayer](https://commercelayer.io) &mdash; Headless Commerce for Global Brands.
 - [commercetools](https://commercetools.com) &mdash; The eCommerce Solution for Innovators and Visionaries.
 - [Medusa](https://www.medusajs.com) &mdash; Medusa is an open-source headless commerce engine that enables developers to create amazing digital commerce experiences.
+- [Spree Commerce](https://spreecommerce.org) &mdash; Open source headless ecommerce platform with B2B, marketplace, multi-store, and cross-border commerce built in. Ships with a TypeScript SDK and reference Next.js storefront.
 - [Unchained Engine](https://unchained.shop/unchained-engine) &mdash; Unchained Engine is an API-driven and Open-Source E-Commerce Framework for Node.js
 - [Vendure](https://www.vendure.io/) &mdash; A headless GraphQL ecommerce framework built on Node.js with Nest & TypeScript, with a focus on developer productivity and ease of customization.
 - [Chord](https://chord.co/) &mdash; The API-first, Data-first Commerce Platform. Created by experts in DTC innovation.


### PR DESCRIPTION
Adding Spree Commerce — open source (BSD 3-Clause) headless ecommerce platform. Recently shipped v5.4 with a TypeScript SDK and reference Next.js storefront.

- Website: https://spreecommerce.org
- Source: https://github.com/spree/spree
- Demo: https://demo.spreecommerce.org