### PR TITLE
Add Payload Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A community curated list of headless commerce related APIs, products, and servic
 - [Storyblok](https://www.storyblok.com) &mdash; Storyblok helps your team to tell your story and manage content for every use-case.
 - [Hygraph](https://hygraph.com) &mdash; The headless CMS powering content for mission-critical applications.
 - [PayloadCMS](https://payloadcms.com/) &mdash; The best way to build a modern backend + admin UI. No black magic, all TypeScript, and fully open-source, Payload is both an app framework and a headless CMS. 
+- [Payload Components](https://www.payload-components.xyz) &mdash; MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 + Next.js projects; copies source, registers blocks, maps renderers, and regenerates Payload types/import map.
 
 ## PIM
 


### PR DESCRIPTION
## Summary

- Add Payload Components to the CMS section.
- Keep the existing PayloadCMS entry unchanged.

## Why it fits

This list already includes PayloadCMS as a headless CMS. Payload Components is a small MIT companion registry/CLI for teams using Payload v3 + Next.js: it installs reusable page blocks as source and wires the Payload collection config, renderer map, generated types, and admin import map.

## Screenshot / links

![Payload Components social card](https://www.payload-components.xyz/opengraph-image)

- Catalog: https://www.payload-components.xyz/components
- Docs: https://www.payload-components.xyz/docs

## Validation

- Checked the CMS section and existing PayloadCMS placement.
- Verified the site, catalog, docs, social card, registry index, and example registry item return 200.