### PR TITLE
Add GitHub Pages Storefront Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ A community curated list of headless commerce related APIs, products, and servic
 - [Payhere](https://payhere.co) &mdash; Easy payment links to help you collect payments online.
 - [Vue storefront](https://vuestorefront.io/) &mdash; Headless PWA frontend for any eCommerce.
 - [commerce-ui](https://commerce-ui.com) &mdash; We build storefronts for headless ecommerce.
+- [GitHub Pages Storefront Starter](https://duct-tape2.github.io/github-pages-storefront-starter/) &mdash; MIT GitHub Pages template and checker for launching a small static storefront with payment links and public-safe buyer workflows.
 - [Frontastic](https://www.frontastic.cloud) &mdash; Rapidly create and evolve mobile first frontends for the API economy.
 - [Front-Commerce](https://www.front-commerce.com) &mdash; PWA frontend for headless eCommerce.
 - [Nacelle](https://nacelle.com) &mdash; Your webstore with sub-second page load speeds, mobile-first functionality and a superior shopping experience.


### PR DESCRIPTION
## Summary

- Add GitHub Pages Storefront Starter to the Storefronts section.

## Why it fits

This is an MIT GitHub Pages storefront template and browser checker for small static storefronts that use payment links and public-safe buyer workflows. It fits alongside the existing storefront/frontend tools in this section.

## Validation

- Checked the existing Storefronts section placement.
- Verified the project page returns HTTP 200 on 2026-07-08.