### PR TITLE
Add HonorBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A community curated list of headless commerce related APIs, products, and servic
 - [Bolt](https://www.bolt.com) &mdash; One Click Checkout.
 - [Foxy](https://foxy.io) &mdash; Foxy’s hosted cart & payment page allow you to sell anything, using your existing website or platform.
 - [Rally](https://rallyon.com) &mdash; A better, more profitable checkout for your brand.
+- [HonorBox](https://honorboxx.github.io/honorbox/) &mdash; Open source checkout and fulfillment for digital products using only Stripe Payment Links and GitHub, with no server or platform fee.
 
 ## Subscriptions
 


### PR DESCRIPTION
Adds [HonorBox](https://honorboxx.github.io/honorbox/) to Cart and Checkout.

HonorBox is an MIT-licensed tool that turns a GitHub repo into a store for digital products: static storefront on GitHub Pages, checkout through Stripe Payment Links on the seller's own account, and fulfillment via a scheduled GitHub Action that invites each buyer's GitHub account to a private product repo — no server, no webhooks, no platform fee. The project's own store runs on the engine unmodified ([repo](https://github.com/Honorboxx/honorbox)).

Entry follows the list format (`&mdash;` separator, appended at the end of the section). Disclosure: I maintain the project.
